### PR TITLE
Fix DPI setting on old mice, e.g. DeathAdder 3.5G

### DIFF
--- a/polychromatic-cli
+++ b/polychromatic-cli
@@ -567,8 +567,12 @@ if args.dpi:
 
         if verbose:
             dbg.stdout("Setting DPI for {0}: {1}".format(device_name, dpi_values))
-
-        result = middleman.set_device_state(device["backend"], device["uid"], device["serial"], None, "dpi", dpi_values, [])
+        
+        if device["dpi_x"] == None:
+            # Device only supports fixed DPI X values, such as DeathAdder 3.5G
+            result = middleman.set_device_state(device["backend"], device["uid"], device["serial"], None, "dpi", dpi_values[0], [])
+        else:
+            result = middleman.set_device_state(device["backend"], device["uid"], device["serial"], None, "dpi", dpi_values, [])
 
         if result == False:
             dbg.stdout(_("Error: [device] - Invalid request!").replace("[device]", device_name), dbg.error)


### PR DESCRIPTION
Some older mice only support fixed DPI X values (and do not support
passing in values for DPI Y). Correct how CLI handles those mice:

- Check whether we are dealing with such a mouse.
- If so, pass only a single value as the argument to the DPI setter
  (i.e. dpi_values[0], where dpi_values = [<dpi_x>, <dpi_y>])
- If not, use old behavior - pass in the full list to the DPI setter
  (i.e. dpi_values)